### PR TITLE
feat(event): refactor event creation to support multipart/form-data and persist event in database

### DIFF
--- a/src/main/java/com/deiziane/eventostec/api/controller/EventController.java
+++ b/src/main/java/com/deiziane/eventostec/api/controller/EventController.java
@@ -1,0 +1,37 @@
+package com.deiziane.eventostec.api.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.deiziane.eventostec.api.domain.event.Event;
+import com.deiziane.eventostec.api.domain.event.EventRequestDTO;
+import com.deiziane.eventostec.api.domain.service.EventService;
+
+@RestController
+@RequestMapping("/api/event")
+public class EventController {
+	
+	@Autowired
+	private EventService eventService;
+	
+	@PostMapping(consumes = "multipart/form-data")
+	public ResponseEntity<Event> create(@RequestParam("title") String title,
+										@RequestParam(value = "description",  required = false) String description,
+										@RequestParam("date") Long date,
+										@RequestParam("city") String city,
+										@RequestParam("uf") String uf,
+										@RequestParam("remote") Boolean remote,
+										@RequestParam("eventUrl") String eventUrl,
+										@RequestParam(value = "image", required = false) MultipartFile image){
+		EventRequestDTO eventRequestDTO = new EventRequestDTO(title, description, date, city, uf, remote, eventUrl, image);
+		Event newEvent = this.eventService.createEvent(eventRequestDTO);
+		return ResponseEntity.ok(newEvent);
+	
+}
+	
+}

--- a/src/main/java/com/deiziane/eventostec/api/domain/service/EventService.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/service/EventService.java
@@ -15,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.amazonaws.services.s3.AmazonS3;
 import com.deiziane.eventostec.api.domain.event.Event;
 import com.deiziane.eventostec.api.domain.event.EventRequestDTO;
+import com.deiziane.eventostec.api.domain.repositories.EventRepository;
 
 @Service
 public class EventService {
@@ -23,6 +24,9 @@ public class EventService {
 
 	@Autowired
 	private AmazonS3 s3client;
+	@Autowired
+	private EventRepository eventRepository;
+
 
 	public Event createEvent(EventRequestDTO data) {
 		String imgUrl = null;
@@ -39,7 +43,9 @@ public class EventService {
 		newEvent.setRemote(data.remote());
 		newEvent.setDate(new Date(data.date()));
 		newEvent.setImgUrl(imgUrl);
-		return newEvent;
+		
+	  Event savedEvent = eventRepository.save(newEvent);
+	  return savedEvent;
 	}
 
 	private String uploadImg(MultipartFile multipartFile) {
@@ -54,7 +60,7 @@ public class EventService {
 			return s3client.getUrl(bucketName, fileName).toString();
 		} catch (Exception e) {
 			System.out.println("Erro ao subir o arquivo.");
-			return null;
+			return "";
 		}
 
 	}


### PR DESCRIPTION
Implementação da refatoração do endpoint de criação de eventos para aceitar requisições do tipo multipart/form-data, possibilitando o envio de imagem junto aos dados do evento e a persistência do evento criado no banco de dados.

Alterações realizadas:
- Atualização do controller `EventController` para uso de `@RequestParam`
- Refatoração do `EventService` para:
  - Persistir o evento no banco de dados via `EventRepository`, gerando os id na criação do evento
  - Realizar o upload da imagem para o bucket