### PR TITLE
feat(event): implement filtering and pagination for upcoming events only

### DIFF
--- a/src/main/java/com/deiziane/eventostec/api/controller/EventController.java
+++ b/src/main/java/com/deiziane/eventostec/api/controller/EventController.java
@@ -19,10 +19,10 @@ import com.deiziane.eventostec.api.domain.service.EventService;
 @RestController
 @RequestMapping("/api/event")
 public class EventController {
-	
+
 	@Autowired
 	private EventService eventService;
-	
+
 	@PostMapping(consumes = "multipart/form-data")
 	public ResponseEntity<Event> create(@RequestParam("title") String title,
 										@RequestParam(value = "description",  required = false) String description,
@@ -35,13 +35,13 @@ public class EventController {
 		EventRequestDTO eventRequestDTO = new EventRequestDTO(title, description, date, city, uf, remote, eventUrl, image);
 		Event newEvent = this.eventService.createEvent(eventRequestDTO);
 		return ResponseEntity.ok(newEvent);
-	
+
 }
 	@GetMapping()
 	public ResponseEntity<List<EventResponseDTO>> getEvent(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size){
-	List<EventResponseDTO> allEvents = this.eventService.getEvents(page, size);
-	
+	List<EventResponseDTO> allEvents = this.eventService.getUpComingEvents(page, size);
+
 	return ResponseEntity.ok(allEvents);
-		
+
 	}
 }

--- a/src/main/java/com/deiziane/eventostec/api/domain/event/EventRequestDTO.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/event/EventRequestDTO.java
@@ -1,7 +1,5 @@
 package com.deiziane.eventostec.api.domain.event;
 
-import java.util.Date;
-
 import org.springframework.web.multipart.MultipartFile;
 
 public record EventRequestDTO(String title, String description, Long date, String city, String uf, boolean remote, String eventUrl, MultipartFile image) {

--- a/src/main/java/com/deiziane/eventostec/api/domain/repositories/EventRepository.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/repositories/EventRepository.java
@@ -1,11 +1,18 @@
 package com.deiziane.eventostec.api.domain.repositories;
-
+import java.util.Date;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.deiziane.eventostec.api.domain.event.Event;
 
 public interface EventRepository extends JpaRepository<Event, UUID>{
+
+	@Query("SELECT e FROM Event e WHERE e.date >= :currentDate")
+	public Page<Event> findUpComingEvents(@Param("currentDate") Date currentDate, Pageable pageable);
 
 }

--- a/src/main/java/com/deiziane/eventostec/api/domain/service/EventService.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/service/EventService.java
@@ -34,7 +34,7 @@ public class EventService {
 
 
 	public Event createEvent(EventRequestDTO data) {
-		String imgUrl = null;
+		String imgUrl = "";
 
 		if (data.image() != null) {
 			imgUrl = this.uploadImg(data.image());
@@ -48,14 +48,14 @@ public class EventService {
 		newEvent.setRemote(data.remote());
 		newEvent.setDate(new Date(data.date()));
 		newEvent.setImgUrl(imgUrl);
-		
+
 	  Event savedEvent = eventRepository.save(newEvent);
 	  return savedEvent;
 	}
 
-	public List<EventResponseDTO> getEvents(int page, int size){
+	public List<EventResponseDTO> getUpComingEvents(int page, int size){
 		Pageable pageable = PageRequest.of(page, size);
-		Page<Event> eventsPage = this.eventRepository.findAll(pageable);
+		Page<Event> eventsPage = this.eventRepository.findUpComingEvents(new Date(), pageable);
 		return eventsPage.map(event -> new EventResponseDTO(
 											event.getId(),
 											event.getTitle(),
@@ -68,7 +68,7 @@ public class EventService {
 											event.getImgUrl()))
 											.stream().toList();
 	}
-	
+
 	private String uploadImg(MultipartFile multipartFile) {
 
 		String fileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();


### PR DESCRIPTION
Implementação da nova funcionalidade no sistema de listagem e paginação de eventos, que permite exibir apenas os eventos que ainda não aconteceram.
Essa melhoria garante melhoria  na experiência do usuário ao listar eventos atuais e futuros, evitando a exibição de eventos passados.