### PR TITLE
feat: implement endpoint to retrieve event details by ID

### DIFF
--- a/src/main/java/com/deiziane/eventostec/api/controller/EventController.java
+++ b/src/main/java/com/deiziane/eventostec/api/controller/EventController.java
@@ -2,11 +2,13 @@ package com.deiziane.eventostec.api.controller;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.deiziane.eventostec.api.domain.event.Event;
+import com.deiziane.eventostec.api.domain.event.EventDetailsDTO;
 import com.deiziane.eventostec.api.domain.event.EventRequestDTO;
 import com.deiziane.eventostec.api.domain.event.EventResponseDTO;
 import com.deiziane.eventostec.api.domain.service.EventService;
@@ -33,17 +36,20 @@ public class EventController {
 			@RequestParam(value = "image", required = false) MultipartFile image) {
 		
 		EventRequestDTO eventRequestDTO = new EventRequestDTO(title, description, date, city, uf, remote, eventUrl,image);
-		
 		Event newEvent = this.eventService.createEvent(eventRequestDTO);
-		
 		return ResponseEntity.ok(newEvent);
 
 	}
+	
+	@GetMapping("{eventId}")
+	public ResponseEntity<EventDetailsDTO> getEventDetails(@PathVariable UUID eventId){
+		EventDetailsDTO eventDetails = eventService.getEventsDetails(eventId);
+		return ResponseEntity.ok(eventDetails);
+		}
 
 	@GetMapping()
 	public ResponseEntity<List<EventResponseDTO>> getEvent(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size){
 	List<EventResponseDTO> allEvents = this.eventService.getUpComingEvents(page, size);
-
 	return ResponseEntity.ok(allEvents);
 	}
 
@@ -58,7 +64,6 @@ public class EventController {
 		
 	
 		  List<EventResponseDTO> events = eventService.getFilteredEvents(page, size, title, city, uf, startDate, endDate);
-	        
 		  return ResponseEntity.ok(events);
 	}
 }

--- a/src/main/java/com/deiziane/eventostec/api/domain/event/EventDetailsDTO.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/event/EventDetailsDTO.java
@@ -1,0 +1,20 @@
+package com.deiziane.eventostec.api.domain.event;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public record EventDetailsDTO(UUID id, 
+							  String title,
+							  String description, 
+							  Date date, 
+							  String city, 
+							  String state,
+							  String imgUrl, 
+							  String eventUrl, 
+							  List<CouponDTO> coupons) {
+
+	public record CouponDTO(String code, Integer discount, Date valid) {
+	
+	}
+}

--- a/src/main/java/com/deiziane/eventostec/api/domain/repositories/CouponRepository.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/repositories/CouponRepository.java
@@ -1,5 +1,7 @@
 package com.deiziane.eventostec.api.domain.repositories;
 
+import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.deiziane.eventostec.api.domain.coupon.Coupon;
 
 public interface CouponRepository extends JpaRepository<Coupon, UUID>{
+	List<Coupon> findByEventIdAndValidAfter(UUID eventId, Date currentDate);
 
 }

--- a/src/main/java/com/deiziane/eventostec/api/domain/repositories/EventRepository.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/repositories/EventRepository.java
@@ -33,6 +33,6 @@ public interface EventRepository extends JpaRepository<Event, UUID>{
 		   						  @Param("startDate") Date startDate,
 		   						  @Param("endDate") Date endDate,
 		   						  Pageable pageable);
-		   						  
+		   						  		
 
 }

--- a/src/main/java/com/deiziane/eventostec/api/domain/service/CouponService.java
+++ b/src/main/java/com/deiziane/eventostec/api/domain/service/CouponService.java
@@ -2,6 +2,7 @@ package com.deiziane.eventostec.api.domain.service;
 
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +26,7 @@ public class CouponService {
 	public Coupon createCoupon( UUID eventId, CouponRequestDTO couponData) {
 
 		Event event = eventRepository.findById(eventId)
-				.orElseThrow(() -> new IllegalArgumentException("Evento não encontrado"));
+				.orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
 		Coupon coupon = new Coupon();
 		coupon.setCode(couponData.code());
@@ -35,6 +36,10 @@ public class CouponService {
 		
 		return couponRepository.save(coupon);
 
+	}
+	
+	public List<Coupon> consultCoupons(UUID eventId, Date currentDate){
+		return couponRepository.findByEventIdAndValidAfter(eventId, currentDate);
 	}
 
 }


### PR DESCRIPTION
Implementação do novo endpoint que permite ao usuário consultar todos os detalhes de um evento específico, inclusive o endereço e cupons associados, utilizando o ID. Essa funcionalidade contribui para a melhoria da experiência do usuário, oferecendo informações completas de forma prática e eficiente.

#### O que foi feito
- Criação do endpoint GET `{eventId}`.
- Implementação da lógica de busca de evento pelo ID no serviço.
- Retorno das informações detalhadas do evento no formato DTO.